### PR TITLE
Fixed entry delete order

### DIFF
--- a/DSL2JSON.py
+++ b/DSL2JSON.py
@@ -54,10 +54,6 @@ class Entry:
 def import_entries(data, dictionaryName, outFile):
     unimported = data.split("\n")
 
-    del unimported[0]
-    del unimported[1]
-    del unimported[2]
-
     unimported.insert(0, "DSL2JSON")
     unimported.insert(1, "\tnoun")
     unimported.insert(2, "\tThis dictionary was imported with DSL2JSON. This is a dummy value for the DSL2JSON converter, ignore this term.")
@@ -145,9 +141,9 @@ encoding = result['encoding']
 
 data, dictionaryName = get_lines(inFile)
 
-del data[0]
-del data[1]
 del data[2]
+del data[1]
+del data[0]
 
 allLines = ""
 allLines = allLines.join(data)


### PR DESCRIPTION
It seems order after get_lines(inFile) (144 line) should be like this. Otherwise you will remove real data, not header lines.
del on 57-59 lines are also remove some real entries.

DSL example I tested here:
[super_short.txt](https://github.com/lrorpilla/DSL2JSON/files/11780167/super_short.txt)
